### PR TITLE
Change how JSON UUIDs and byte arrays are exported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/runZeroInc/mustache/v2
 go 1.23
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.0.0
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/mustache.go
+++ b/mustache.go
@@ -819,7 +819,10 @@ func (tmpl *Template) renderElement(element any, contextChain []any, buf io.Writ
 						if err != nil {
 							return err
 						}
-						buf.Write(marshalledJson)
+						_, err = buf.Write(marshalledJson)
+						if err != nil {
+							return err
+						}
 						break
 					}
 					if err = JSONEscape(buf, s); err != nil {

--- a/mustache.go
+++ b/mustache.go
@@ -781,9 +781,40 @@ func (tmpl *Template) renderElement(element any, contextChain []any, buf io.Writ
 				s := fmt.Sprint(val.Interface())
 				switch tmpl.outputMode {
 				case EscapeJSON:
+					// Whether to use JSON's marshalling (true) or our JSON escaping (false)
+					useMarshal := false
+
+					var kind reflect.Kind
+					typeof := reflect.TypeOf(val.Interface())
+					if typeof != nil {
+						kind = typeof.Kind()
+					}
+
 					// Output arrays and objects in JSON format, if in JSON mode
-					kind := reflect.TypeOf(val.Interface()).Kind()
 					if kind == reflect.Slice || kind == reflect.Array || kind == reflect.Map {
+						useMarshal = true
+					}
+
+					//
+					// Special case overrides
+					//
+					if typeof != nil {
+						switch typeof.String() {
+						case "uuid.UUID":
+							// JSON's implementation encloses UUID in double-quotes,
+							// so use ours instead
+							useMarshal = false
+						case "[]uint8":
+							// JSON's implementation encloses the base64 encoded value in double quotes,
+							// so use ours instead
+							if ba, ok := val.Interface().([]byte); ok {
+								s = string(ba[:])
+								useMarshal = false
+							}
+						}
+					}
+
+					if useMarshal {
 						marshalledJson, err := json.Marshal(val.Interface())
 						if err != nil {
 							return err

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 type Test struct {
@@ -452,6 +454,8 @@ func TestRenderJSON(t *testing.T) {
 		Name  string
 	}
 
+	testUuid := uuid.New()
+
 	tests := []struct {
 		Template string
 		Data     map[string]any
@@ -504,6 +508,20 @@ func TestRenderJSON(t *testing.T) {
 				},
 			},
 			Result: `[4,5,6]`,
+		},
+		{
+			Template: `{{uuid}}`,
+			Data: map[string]any{
+				"uuid": testUuid,
+			},
+			Result: testUuid.String(),
+		},
+		{
+			Template: `{{byteAry}}`,
+			Data: map[string]any{
+				"byteAry": []byte("foobar🟡"),
+			},
+			Result: "foobar🟡",
 		},
 	}
 	for _, tst := range tests {


### PR DESCRIPTION
This changes how uuid.UUID and byte array types are exported to JSON.

### Problem
Previously, UUID's were exported as the UUID string enclosed in double quotes.  []byte arrays were exported as the base64 representation enclosed in double quotes.  While this is a correct JSON representation, users tend to treat these values the same way they do with strings (which aren't rendered in enclosed quotes) in their templates.

So a template like:
```
myname := "foo"
myuuid := uuid.New()
{
  "name": "{{myname}}",
  "uuid": "{{myuuid}}"
}
```
would be rendered as:
```
{
  "name": "foo",
  "uuid": ""43159902-7171-30cf-ab7e-ee36986c37c6""
}
```

### Fix
This PR adds special cases that override when to use the JSON marshaller vs our own JSONEscape method.  It adds special cases for UUIDs and byte arrays.